### PR TITLE
fix log history strategy

### DIFF
--- a/src/file_status.rs
+++ b/src/file_status.rs
@@ -37,17 +37,10 @@ pub fn rename_log_with_timestamp(pathstr: &str) -> Result<(), &'static str> {
             return Err("Failed in rename_log_with_timestamp!");
         }
     };
-    let f = match std::fs::File::open(pathstr){
-        Ok(res) => res,
-        Err(err) => {
-            error!("In rename_log_with_timestamp, open({}):{}", pathstr, err);
-            return Err("Failed in rename_log_with_timestamp!");
-        }
-    };
-    match f.set_len(0){
+    match FileStatus::delete_file(pathstr){
         Ok(_) => (),
         Err(err) => {
-            error!("In rename_log_with_timestamp, set_len(0):{}", err);
+            error!("In rename_log_with_timestamp, delete_file({}):{}", pathstr, err);
             return Err("Failed in rename_log_with_timestamp!");
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,9 @@ use crate::file_status::rename_log_with_timestamp;
 
 
 fn main()-> Result<(), &'static str>{
-    log4rs::init_file("config/log4rs.yaml", Default::default()).unwrap();
     // see config/log4ts.yaml
     rename_log_with_timestamp("log/wdinfo.log")?;
+    log4rs::init_file("config/log4rs.yaml", Default::default()).unwrap();
     
     let mut wd=WDInfo::default();
 


### PR DESCRIPTION
Handle log file before log4rs use it.
Instead of open log file and set_len(0), just delete it.